### PR TITLE
Fix top state on NavBar.js

### DIFF
--- a/src/components/Navbar/NavBar.js
+++ b/src/components/Navbar/NavBar.js
@@ -4,7 +4,7 @@ import { HashLink } from 'react-router-hash-link';
 
 
 const NavBar = () => {
-    const [top, setTop] = useState(true);
+    const [top, setTop] = useState(!window.scrollY);
     const [isOpen, setisOpen] = React.useState(false);
     function handleClick() {
         setisOpen(!isOpen);


### PR DESCRIPTION
When opening a page, it's not always scrolled up to the top. Sometimes it opens on the middle of the page. That's why we need to check if it's scrolled with `window.scrollY` and then set it to `top` state.